### PR TITLE
If Headers are already sent, don't flush them again

### DIFF
--- a/app.php
+++ b/app.php
@@ -398,9 +398,9 @@
 		return response($body, 500);
 	}
 
-	function response_json($values)
+	function response_json($values, $status_code=200)
 	{
-		return response(json_encode($values), 200, array('content-type' => 'application/json; charset=utf-8'));
+		return response(json_encode($values), $status_code, array('content-type' => 'application/json; charset=utf-8'));
 	}
 
 
@@ -442,6 +442,9 @@
 
 		function flush($status_code, $headers, $body)
 		{
+			if (headers_sent()) {
+        			return;
+    			}
 			flush_status_line($status_code);
 			flush_headers($headers);
 			flush_body($body);


### PR DESCRIPTION
In the flush method, checking if the headers are already sent, then don't send them again. Else PHP will show a warning. We are using bshaffer/oauth2-server-php OAuth library which does the user cred validation and then sets the header and body internally.

Also the response_json() method now takes an optional http response status, so that we can set http response status other than 200