### PR TITLE
Removed response_json() method

### DIFF
--- a/app.php
+++ b/app.php
@@ -398,12 +398,6 @@
 		return response($body, 500);
 	}
 
-	function response_json($values)
-	{
-		return response(json_encode($values), 200, array('content-type' => 'application/json; charset=utf-8'));
-	}
-
-
 	function exit_with($body, $status_code=200, $headers=array())
 	{
 		if (!isset($headers['content-type']))


### PR DESCRIPTION
response method has built in capability to turn an array into json. So we don't need an extra response_json method.